### PR TITLE
Emulate real Mac keys

### DIFF
--- a/BTHSControl/BTHSInterface.m
+++ b/BTHSControl/BTHSInterface.m
@@ -72,12 +72,12 @@ static void HIDPostAuxKey( const UInt8 auxKeyCode )
 
 + (void)forward
 {
-    HIDPostAuxKey(NX_KEYTYPE_NEXT);
+    HIDPostAuxKey(NX_KEYTYPE_FAST);
 }
 
 + (void)back
 {
-    HIDPostAuxKey(NX_KEYTYPE_PREVIOUS);
+    HIDPostAuxKey(NX_KEYTYPE_REWIND);
 }
 
 @end


### PR DESCRIPTION
Mac keys on a keyboard are technically fast-forward and rewind instead of next and previous. Most OS X applications I know listen to these keys so it would make sense to use these instead of the 'probably less supported' next/previous keys.
Spotify on OS X 10.9.4 didn't work without this change.
